### PR TITLE
gralloc_drm_intel: initialize extra_height_div as 0

### DIFF
--- a/gralloc_drm_intel.c
+++ b/gralloc_drm_intel.c
@@ -70,7 +70,7 @@ static void calculate_aligned_geometry(uint32_t hal_format, int usage,
 		uint32_t *width,
 		uint32_t *height)
 {
-	uint32_t width_alignment = 1, height_alignment = 1, extra_height_div =1;
+	uint32_t width_alignment = 1, height_alignment = 1, extra_height_div = 0;
 	uint32_t fourcc_format = get_fourcc_format_for_hal_format(hal_format);
 	switch(fourcc_format) {
 	case DRM_FORMAT_YUV420:


### PR DESCRIPTION
Currently we end up allocating too big surfaces and end up with failures
when creating framebuffers, as example for 1920x1080:

   hwc-platform-IA: drmModeAddFB2 error (1920x2160, AB24, handle 3 pitch 7680)

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>