### PR TITLE
Make it possible to use both drm_hwcomposer and hwcomposer

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -95,8 +95,13 @@ LOCAL_C_INCLUDES := \
 	vendor/intel/external/android_ia/libdrm \
 	vendor/intel/external/android_ia/libdrm/include/drm
 
+ifeq ($(strip $(BOARD_USES_DRM_HWCOMPOSER)),true)
+LOCAL_CFLAGS += -isystem vendor/intel/external/android_ia/drm_hwcomposer
+LOCAL_CFLAGS += -DDRM_HWCOMPOSER
+else
 LOCAL_CFLAGS += -isystem vendor/intel/external/android_ia/hwcomposer/public \
 	-isystem vendor/intel/external/android_ia/hwcomposer/os/android
+endif
 
 LOCAL_SHARED_LIBRARIES := \
 	libdrm \
@@ -173,8 +178,13 @@ LOCAL_C_INCLUDES := \
 	vendor/intel/external/android_ia/libdrm \
 	vendor/intel/external/android_ia/libdrm/include/drm
 
+ifeq ($(strip $(BOARD_USES_DRM_HWCOMPOSER)),true)
+LOCAL_CFLAGS += -isystem vendor/intel/external/android_ia/drm_hwcomposer
+LOCAL_CFLAGS += -DDRM_HWCOMPOSER
+else
 LOCAL_CFLAGS += -isystem vendor/intel/external/android_ia/hwcomposer/public \
 	-isystem vendor/intel/external/android_ia/hwcomposer/os/android
+endif
 
 LOCAL_SHARED_LIBRARIES := \
 	libgralloc_drm \

--- a/gralloc.cpp
+++ b/gralloc.cpp
@@ -30,7 +30,11 @@
 #include <errno.h>
 #include <map>
 
+#ifdef DRM_HWCOMPOSER
+#include "drmhwcgralloc.h"
+#else
 #include "grallocbufferhandler.h"
+#endif
 #include "gralloc_drm.h"
 #include "gralloc_drm_priv.h"
 
@@ -122,12 +126,37 @@ static int drm_mod_perform(const struct gralloc_module_t *mod, int op, ...)
 			err = 0;
 		}
 		break;
+#ifdef DRM_HWCOMPOSER
+	case static_cast<int>(GRALLOC_MODULE_PERFORM_GET_USAGE):
+		{
+			buffer_handle_t handle = va_arg(args, buffer_handle_t);
+			int *buffer_usage = va_arg(args, int *);
+			gralloc_drm_handle_t *gr_handle = gralloc_drm_handle(handle);
+
+			if (!gr_handle) {
+				ALOGE("could not find gralloc drm handle");
+				err = -EINVAL;
+				break;
+			}
+
+			if (gr_handle->usage & GRALLOC_USAGE_PROTECTED) {
+				*buffer_usage = 0;
+			} else {
+				*buffer_usage = gr_handle->usage;
+			}
+			err = 0;
+		}
+		break;
+#endif
 	case static_cast<int>(GRALLOC_MODULE_PERFORM_DRM_IMPORT):
 		{
 			int fd = va_arg(args, int);
 			buffer_handle_t handle = va_arg(args, buffer_handle_t);
+#ifdef DRM_HWCOMPOSER
+			hwc_drm_bo_t *hwc_bo = va_arg(args, hwc_drm_bo_t *);
+#else
 			struct HwcBuffer *hwc_bo = va_arg(args, struct HwcBuffer *);
-
+#endif
 			gralloc_drm_handle_t *gr_handle = gralloc_drm_handle(handle);
 
 			if (!gr_handle) {
@@ -143,6 +172,7 @@ static int drm_mod_perform(const struct gralloc_module_t *mod, int op, ...)
 				err = -EINVAL;
 		}
 		break;
+#ifndef DRM_HWCOMPOSER
 	case static_cast<int>(GRALLOC_MODULE_PERFORM_CREATE_BUFFER):
 		{
 			uint32_t width = va_arg(args, uint32_t);
@@ -160,6 +190,7 @@ static int drm_mod_perform(const struct gralloc_module_t *mod, int op, ...)
 			err = drm_mod_destroy_buffer(handle);
 		}
 		break;
+#endif
 	default:
 		err = -EINVAL;
 		break;
@@ -275,9 +306,32 @@ static int drm_mod_close_gpu0(struct hw_device_t *dev)
 	return 0;
 }
 
+#ifdef DRM_HWCOMPOSER
+static int drm_mod_free_gpu0(alloc_device_t *dev, buffer_handle_t handle)
+#else
 static int drm_mod_free_gpu0(alloc_device_t */*dev*/, buffer_handle_t handle)
+#endif
 {
+#ifdef DRM_HWCOMPOSER
+	struct drm_module_t *dmod = (struct drm_module_t *) dev->common.module;
+	struct gralloc_drm_bo_t *bo;
+
+	bo = gralloc_drm_bo_from_handle(handle);
+	if (!bo)
+		return -EINVAL;
+
+	gralloc_drm_bo_decref(bo);
+
+	std::map<gralloc_drm_bo_t *,
+		buffer_handle_t *>::const_iterator it = all_records.find(bo);
+	if (it == all_records.end())
+		return -EINVAL;
+	all_records.erase(it);
+
+	return 0;
+#else
 	return drm_mod_destroy_buffer(handle);
+#endif
 }
 
 static int drm_mod_alloc_gpu0(alloc_device_t *dev,
@@ -285,7 +339,34 @@ static int drm_mod_alloc_gpu0(alloc_device_t *dev,
 		buffer_handle_t *handle, int *stride)
 {
 	struct drm_module_t *dmod = (struct drm_module_t *) dev->common.module;
+#ifdef DRM_HWCOMPOSER
+	struct gralloc_drm_bo_t *bo;
+	int size, bpp, err;
+
+        if (format == HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED) {
+                ALOGV("Convert implementation defined format to ARGB8888 w:%d, h:%d, usage:0x%x",
+                        w, h, usage);
+                format = HAL_PIXEL_FORMAT_RGBA_8888;
+        }
+
+	bpp = gralloc_drm_get_bpp(format);
+	if (!bpp)
+		return -EINVAL;
+
+	bo = gralloc_drm_bo_create(dmod->drm, w, h, format, usage);
+	if (!bo)
+		return -ENOMEM;
+
+	*handle = gralloc_drm_bo_get_handle(bo, stride);
+	/* in pixels */
+	*stride /= bpp;
+
+	all_records.insert(std::make_pair(bo, handle));
+
+	return 0;
+#else
 	return drm_mod_create_buffer(dmod, w, h, format, usage, handle, stride);
+#endif
 }
 
 static void drm_mod_dump_gpu0(struct alloc_device_t * /*dev*/, char *buff, int buff_len)

--- a/gralloc_drm_priv.h
+++ b/gralloc_drm_priv.h
@@ -27,8 +27,11 @@
 #include <pthread.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
-
+#ifdef DRM_HWCOMPOSER
+#include "drmhwcgralloc.h"
+#else
 #include "hwcbuffer.h"
+#endif
 #include "gralloc_drm_handle.h"
 
 #ifdef __cplusplus
@@ -78,7 +81,11 @@ struct gralloc_drm_drv_t {
 	int (*resolve_buffer)(struct gralloc_drm_drv_t *drv,
 			int fd,
 			struct gralloc_drm_handle_t *handle,
-			struct HwcBuffer *hwc_bo);
+#ifdef DRM_HWCOMPOSER
+			hwc_drm_bo_t *hwc_bo);
+#else
+	                struct HwcBuffer *hwc_bo);
+#endif
 };
 
 struct gralloc_drm_bo_t {
@@ -86,7 +93,11 @@ struct gralloc_drm_bo_t {
 	struct gralloc_drm_handle_t *handle;
 
 	int imported;  /* the handle is from a remote proces when true */
+#ifdef DRM_HWCOMPOSER
+	int fb_handle; /* the GEM handle of the bo */
+#else
 	uint32_t fb_handle; /* the GEM handle of the bo */
+#endif
 	int fb_id;     /* the fb id */
 
 	int lock_count;


### PR DESCRIPTION
Provide build time configuration to choose between drm_hwcomposer
and hwcomposer.

Jira: None
Test: Build and boot to homescreen for both HWComposers

Signed-off-by: Marta Lofstedt <marta.lofstedt@intel.com>