### PR TITLE
gralloc: Fix YV12 cb and cr offsets

### DIFF
--- a/gralloc.cpp
+++ b/gralloc.cpp
@@ -189,10 +189,9 @@ static int drm_mod_lock_ycbcr(const gralloc_module_t *mod, buffer_handle_t bhand
 
 	switch(handle->format) {
 	case HAL_PIXEL_FORMAT_YV12:
-	case HAL_PIXEL_FORMAT_YCbCr_420_888:
 		ycbcr->y = ptr;
-		ycbcr->cb = (uint8_t *)ptr + (offsets[1] - offsets[2]);
-		ycbcr->cr = (uint8_t *)ptr + (offsets[2] - offsets[0]);
+		ycbcr->cb = (uint8_t *)ptr + offsets[1];
+		ycbcr->cr = (uint8_t *)ptr + offsets[2];
 		ycbcr->ystride = pitches[0];
 		ycbcr->cstride = pitches[1];
 		ycbcr->chroma_step = 1;


### PR DESCRIPTION
The previous implementation was hiding a bug in Mesa
platform_android. The ordering of the cr and cb components was
wrong. This is fixed in Mesa with:
https://patchwork.freedesktop.org/patch/136514/

JIRA: https://01.org/jira/browse/AIA-80

Test: framworks/native/opengl/tests/gl2_yuxtex

Signed-off-by: Marta Lofstedt <marta.lofstedt@intel.com>